### PR TITLE
Added Acessibility.css

### DIFF
--- a/runestone/common/css/accessibility.css
+++ b/runestone/common/css/accessibility.css
@@ -1,0 +1,142 @@
+/*Navigation Tabbing Styling*/
+li.dropdown.open a.dropdown-toggle, li.dropdown.open a.dropdown-toggle:focus {
+	border:0px !important;
+	/*background-color: #346A6E!important;*/
+	background-color: #2A5659 !important;
+	color:#F8F8F8 !important;
+}
+a.dropdown-toggle:focus {
+	 /*border:1px solid #5B9DD9 !important;
+	 color:#5B9DD9 !important;
+	 width:48px !important;*/
+	 background-color: #52A6AC!important;
+	 color:#F8F8F8 !important;
+}
+/* Border Manipulation */
+li.divider-vertical {
+	margin:0px !important;
+}
+li.dropdown a.dropdown-toggle {
+	padding:15px 18px !important;
+}
+
+/*
+Bootstrap button styling  
+*/
+
+/* Default Button */
+/* Passes WCAG 2.0 */
+button.btn.btn-default:active {
+	color:#474949 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-default:focus {
+	color:#474949 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-default{
+	color:#FFFFFF !important;
+	background-color:#474949 !important;
+}
+button.btn.btn-default.btn-sm.disabled:active {
+	color:#474949 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-default.btn-sm.disabled:focus {
+	color:#474949 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-default.btn-sm.disabled{
+	color:#FFFFFF !important;
+	background-color:#474949 !important;
+}
+/* Sucess Button */
+/* Failed WCAG 2.0, #255425 passes */
+button.btn.btn-success:active {
+	color:#427e44 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-success:focus {
+	color:#427e44!important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-success {
+	color:#FFFFFF !important;
+	background-color:#427e44!important;
+}
+
+/*Primary Button*/
+/* fails WCAG 2.0, #265986 passes */
+button.btn.btn-primary:active {
+	color:#3379b6!important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-primary:focus {
+	color:#3379b6 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-primary {
+	color:#FFFFFF !important;
+	background-color:#3379b6 !important;
+}
+
+
+/*Info Button */
+/* Fails, WCAG 2.0, #155569 passes*/
+button.btn.btn-info:active {
+	color:#1a6a83!important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-info:focus {
+	color:#1a6a83 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-info{
+	color:#FFFFFF !important;
+	background-color:#1a6a83 !important;
+}
+
+/*Warning Button*/
+/*Fails WCAG 2.0, #794b0b*/
+button.btn.btn-warning:active {
+	color:#945c0e !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-warning:focus {
+	color:#945c0e !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-warning {
+	color:#FFFFFF !important;
+	background-color:#945c0e !important;
+}
+
+/*Danger Button */
+/*Fails, #a62924 passes*/
+button.btn.btn-danger:active {
+	color:#d33a35 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-danger:focus {
+	color:#d33a35 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-danger{
+	color:#FFFFFF !important;
+	background-color:#d33a35 !important;
+}
+
+/*Link Button*/
+/*Fails AAA, passes with #265986*/
+button.btn.btn-link:active {
+	color:#FFFFFF!important;
+	background-color:#1a6a83 !important;
+}
+button.btn.btn-link:focus {
+	color:#FFFFFF !important;
+	background-color:#1a6a83 !important;
+}
+button.btn.btn-link {
+	color:#1a6a83 !important;
+	background-color:#FFFFFF !important;
+}

--- a/runestone/common/css/accessibilitydarkest.css
+++ b/runestone/common/css/accessibilitydarkest.css
@@ -1,0 +1,142 @@
+/*Navigation Tabbing Styling*/
+li.dropdown.open a.dropdown-toggle, li.dropdown.open a.dropdown-toggle:focus {
+	border:0px !important;
+	/*background-color: #346A6E!important;*/
+	background-color: #2A5659 !important;
+	color:#F8F8F8 !important;
+}
+a.dropdown-toggle:focus {
+	 /*border:1px solid #5B9DD9 !important;
+	 color:#5B9DD9 !important;
+	 width:48px !important;*/
+	 background-color: #52A6AC!important;
+	 color:#F8F8F8 !important;
+}
+/* Border Manipulation */
+li.divider-vertical {
+	margin:0px !important;
+}
+li.dropdown a.dropdown-toggle {
+	padding:15px 18px !important;
+}
+
+/*
+Bootstrap button styling  
+*/
+
+/* Default Button */
+/* Passes WCAG 2.0 */
+button.btn.btn-default:active {
+	color:#474949 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-default:focus {
+	color:#474949 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-default{
+	color:#FFFFFF !important;
+	background-color:#474949 !important;
+}
+button.btn.btn-default.btn-sm.disabled:active {
+	color:#474949 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-default.btn-sm.disabled:focus {
+	color:#474949 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-default.btn-sm.disabled{
+	color:#FFFFFF !important;
+	background-color:#474949 !important;
+}
+/* Sucess Button */
+/* Failed WCAG 2.0, #255425 passes */
+button.btn.btn-success:active {
+	color:#255425 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-success:focus {
+	color:#255425 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-success {
+	color:#FFFFFF !important;
+	background-color:#255425 !important;
+}
+
+/*Primary Button*/
+/* fails WCAG 2.0, #265986 passes */
+button.btn.btn-primary:active {
+	color:#265986 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-primary:focus {
+	color:#265986 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-primary {
+	color:#FFFFFF !important;
+	background-color:#265986 !important;
+}
+
+
+/*Info Button */
+/* Fails, WCAG 2.0, #155569 passes*/
+button.btn.btn-info:active {
+	color:#155569 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-info:focus {
+	color:#155569  !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-info{
+	color:#FFFFFF !important;
+	background-color:#155569 !important;
+}
+
+/*Warning Button*/
+/*Fails WCAG 2.0, #794b0b*/
+button.btn.btn-warning:active {
+	color:#794b0b !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-warning:focus {
+	color:#794b0b !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-warning {
+	color:#FFFFFF !important;
+	background-color:#794b0b !important;
+}
+
+/*Danger Button */
+/*Fails, #a62924 passes*/
+button.btn.btn-danger:active {
+	color:#a62924 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-danger:focus {
+	color:#a62924 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-danger{
+	color:#FFFFFF !important;
+	background-color: #a62924 !important;
+}
+
+/*Link Button*/
+/*Fails AAA, passes with #265986*/
+button.btn.btn-link:active {
+	color:#FFFFFF!important;
+	background-color:#265986 !important;
+}
+button.btn.btn-link:focus {
+	color:#FFFFFF !important;
+	background-color:#265986 !important;
+}
+button.btn.btn-link {
+	color:#265986 !important;
+	background-color:#FFFFFF !important;
+}

--- a/runestone/common/css/accessibilitylight.css
+++ b/runestone/common/css/accessibilitylight.css
@@ -1,0 +1,110 @@
+/*Navigation Tabbing Styling*/
+li.dropdown.open a.dropdown-toggle, li.dropdown.open a.dropdown-toggle:focus {
+	border:0px !important;
+	/*background-color: #346A6E!important;*/
+	background-color: #2A5659 !important;
+	color:#F8F8F8 !important;
+}
+a.dropdown-toggle:focus {
+	 /*border:1px solid #5B9DD9 !important;
+	 color:#5B9DD9 !important;
+	 width:48px !important;*/
+	 background-color: #52A6AC!important;
+	 color:#F8F8F8 !important;
+}
+/* Border Manipulation */
+li.divider-vertical {
+	margin:0px !important;
+}
+li.dropdown a.dropdown-toggle {
+	padding:15px 18px !important;
+}
+
+/*
+Bootstrap button styling  
+*/
+
+/* Default Button */
+/* Passes WCAG 2.0 */
+button.btn.btn-default:active {
+	color:#474949 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-default:focus {
+	color:#474949 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-default.btn-sm.disabled:active {
+	color:#474949 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-default.btn-sm.disabled:focus {
+	color:#474949 !important;
+	background-color:#FFFFFF !important;
+}
+/* Sucess Button */
+/* Failed WCAG 2.0, #255425 passes */
+button.btn.btn-success:active {
+	color:#5CB85C !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-success:focus {
+	color:#5CB85C !important;
+	background-color:#FFFFFF !important;
+}
+
+/*Primary Button*/
+/* fails WCAG 2.0, #265986 passes */
+button.btn.btn-primary:active {
+	color:#337AB7 !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-primary:focus {
+	color:#337AB7 !important;
+	background-color:#FFFFFF !important;
+}
+
+
+/*Info Button */
+/* Fails, WCAG 2.0, #155569 passes*/
+button.btn.btn-info:active {
+	color:#5BC0DE!important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-info:focus {
+	color:#5BC0DE !important;
+	background-color:#FFFFFF !important;
+}
+
+/*Warning Button*/
+/*Fails WCAG 2.0, #794b0b*/
+button.btn.btn-warning:active {
+	color:#F0AD4E !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-warning:focus {
+	color:#F0AD4E !important;
+	background-color:#FFFFFF !important;
+}
+
+/*Danger Button */
+/*Fails, #a62924 passes*/
+button.btn.btn-danger:active {
+	color:#D9534F !important;
+	background-color:#FFFFFF !important;
+}
+button.btn.btn-danger:focus {
+	color:#D9534F !important;
+	background-color:#FFFFFF !important;
+}
+
+/*Link Button*/
+/*Fails AAA, passes with #265986*/
+button.btn.btn-link:active {
+	color:#FFFFFF!important;
+	background-color:#337AB7 !important;
+}
+button.btn.btn-link:focus {
+	color:#FFFFFF !important;
+	background-color:#337AB7 !important;
+}

--- a/runestone/common/css/codemirror.css
+++ b/runestone/common/css/codemirror.css
@@ -1,5 +1,5 @@
 /* BASICS */
-
+@import url("accessibility.css");
 .CodeMirror {
   /* Set height, width, borders, and global font properties here */
   font-family: monospace;


### PR DESCRIPTION
Acessility CSS covers
- Change of nav bar to color code based on Users using either mouse or
keyboard to navigate the menu
- Adjusting bootstrap buttons to invert color on active and on focus for
accessibility for users
- Changing default bootstrap buttons to follow WCAG 2.0 guidlines
- acessibility.css reflects WCAG 2.0 AA compliance
- acessibilitydarkest.css reflects WCAG 2.0 AAA compliance
- accessibilitylight.css doesn't change bootstrap colors but adds
inversion

Personally we prefered WCAG 2.0 AA compliance, so accessibility.css
reflects ideal changes

http://imgur.com/a/TSDNf
This shows the different CSS files from most compliance (left) to least
compliance (right)

*note: I couldn't get accessibility.css to generate an HTML reference
when the files were built, so I included a work around of importing
accessibility.css into codemirror.css